### PR TITLE
[FEAT] 이메일 중복 확인 API 및 UI 컴포넌트 구현

### DIFF
--- a/app/api/auth/check-email/route.ts
+++ b/app/api/auth/check-email/route.ts
@@ -4,16 +4,17 @@ import { NextRequest, NextResponse } from 'next/server';
 interface CheckEmailResponse {
   message: string;
   data: {
-    isAvailable: boolean;
+    available: boolean;
   };
 }
 
-export async function POST(request: NextRequest) {
-  const { email } = await request.json();
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const email = searchParams.get('email');
 
   try {
-    const response = await httpServer.post('/auth/check-email', email);
-    return NextResponse.json(response);
+    const response: CheckEmailResponse = await httpServer.get(`/auth/check-email?email=${email}`);
+    return NextResponse.json(response.data);
   } catch (error) {
     return NextResponse.json({ message: error }, { status: 500 });
   }

--- a/app/api/auth/check-email/route.ts
+++ b/app/api/auth/check-email/route.ts
@@ -1,0 +1,20 @@
+import { httpServer } from '@/src/shared/utils/httpServer';
+import { NextRequest, NextResponse } from 'next/server';
+
+interface CheckEmailResponse {
+  message: string;
+  data: {
+    isAvailable: boolean;
+  };
+}
+
+export async function POST(request: NextRequest) {
+  const { email } = await request.json();
+
+  try {
+    const response = await httpServer.post('/auth/check-email', email);
+    return NextResponse.json(response);
+  } catch (error) {
+    return NextResponse.json({ message: error }, { status: 500 });
+  }
+}

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -40,24 +40,6 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json({ message: '로그인 성공' }, { status: 200 });
   } catch (error) {
-    console.error('로그인 요청 실패');
-
-    if (error instanceof Error) {
-      return NextResponse.json(
-        {
-          errorCode: 'AUTHENTICATION_FAILED',
-          errorMessage: '로그인에 실패했습니다. 이메일과 비밀번호를 확인해주세요.',
-        },
-        { status: 401 },
-      );
-    }
-
-    return NextResponse.json(
-      {
-        errorCode: 'INTERNAL_SERVER_ERROR',
-        errorMessage: '서버 내부 오류가 발생했습니다. 다시 시도해주세요.',
-      },
-      { status: 500 },
-    );
+    return NextResponse.json({ message: error }, { status: 500 });
   }
 }

--- a/app/api/auth/loginGoogle/route.ts
+++ b/app/api/auth/loginGoogle/route.ts
@@ -16,10 +16,6 @@ export async function GET() {
 
     return NextResponse.redirect(googleLoginUrl);
   } catch (error) {
-    console.error('Error logging in with Google in Server Side:', error);
-    return NextResponse.json(
-      { error: 'Failed to login with Google in Server Side' },
-      { status: 500 },
-    );
+    return NextResponse.json({ message: error }, { status: 500 });
   }
 }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -19,7 +19,6 @@ export async function POST() {
     await deleteTokens();
     return NextResponse.json({ message: '로그아웃 성공' }, { status: 200 });
   } catch (error) {
-    console.error('로그아웃 실패', error);
-    return NextResponse.json({ message: '로그아웃 실패' }, { status: 500 });
+    return NextResponse.json({ message: error }, { status: 500 });
   }
 }

--- a/app/api/auth/signupGoogle/route.ts
+++ b/app/api/auth/signupGoogle/route.ts
@@ -46,13 +46,7 @@ export async function POST(req: NextRequest) {
     });
 
     return NextResponse.json(user, { status: 201 });
-  } catch {
-    return NextResponse.json(
-      {
-        errorCode: 'SIGNUP_FAILED',
-        errorMessage: 'Signup failed. Please check your input information.',
-      },
-      { status: 500 },
-    );
+  } catch (error) {
+    return NextResponse.json({ message: error }, { status: 500 });
   }
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 export default function SignupPage() {
   return (
     <div className='flex min-h-screen items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100 px-4 py-8'>
-      <div className='w-full max-w-md'>
+      <div className='w-full max-w-lg'>
         <Image
           src='/VitalTrip.svg'
           alt='VitalTrip Logo'

--- a/src/features/auth/api/checkEmail.ts
+++ b/src/features/auth/api/checkEmail.ts
@@ -1,6 +1,10 @@
 import { httpClient } from '@/src/shared/utils/httpClient';
 
-export const checkEmail = async (email: string) => {
-  const response = await httpClient.post('/api/auth/check-email', email);
+interface CheckEmailResponse {
+  available: boolean;
+}
+
+export const checkEmail = async (email: string): Promise<CheckEmailResponse> => {
+  const response: CheckEmailResponse = await httpClient.get(`/api/auth/check-email?email=${email}`);
   return response;
 };

--- a/src/features/auth/api/checkEmail.ts
+++ b/src/features/auth/api/checkEmail.ts
@@ -1,0 +1,6 @@
+import { httpClient } from '@/src/shared/utils/httpClient';
+
+export const checkEmail = async (email: string) => {
+  const response = await httpClient.post('/api/auth/check-email', email);
+  return response;
+};

--- a/src/features/auth/hooks/useCheckEmail.ts
+++ b/src/features/auth/hooks/useCheckEmail.ts
@@ -17,7 +17,7 @@ export const useCheckEmail = () => {
         setIsAvailable(false);
         setMessage('이미 사용 중인 이메일입니다.');
       }
-    } catch (error) {
+    } catch {
       setIsAvailable(false);
       setMessage('이메일 중복 확인에 실패했습니다.');
     } finally {

--- a/src/features/auth/hooks/useCheckEmail.ts
+++ b/src/features/auth/hooks/useCheckEmail.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { checkEmail as checkEmailApi } from '../api/checkEmail';
+
+export const useCheckEmail = () => {
+  const [isAvailable, setIsAvailable] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [message, setMessage] = useState<string>('');
+
+  const checkEmail = async (email: string) => {
+    setIsLoading(true);
+    try {
+      const { available } = await checkEmailApi(email);
+      if (available) {
+        setIsAvailable(true);
+        setMessage('사용 가능한 이메일입니다.');
+      } else if (!available) {
+        setIsAvailable(false);
+        setMessage('이미 사용 중인 이메일입니다.');
+      }
+    } catch (error) {
+      setIsAvailable(false);
+      setMessage('이메일 중복 확인에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { message, isAvailable, checkEmail, isLoading };
+};

--- a/src/features/auth/ui/CheckEmailButton.tsx
+++ b/src/features/auth/ui/CheckEmailButton.tsx
@@ -6,7 +6,7 @@ interface CheckEmailButtonProps {
 export const CheckEmailButton = ({ onCheck, isLoading }: CheckEmailButtonProps) => {
   return (
     <button
-      className='rounded-md bg-blue-500 px-1 font-semibold text-white transition-colors duration-300 hover:bg-blue-600 disabled:bg-blue-300'
+      className='rounded-md bg-blue-500 px-1 font-semibold text-white transition-colors duration-300 hover:bg-blue-600 disabled:bg-blue-300 disabled:px-2 disabled:py-3'
       onClick={onCheck}
       disabled={isLoading}
     >

--- a/src/features/auth/ui/CheckEmailButton.tsx
+++ b/src/features/auth/ui/CheckEmailButton.tsx
@@ -1,9 +1,9 @@
-interface EmailCheckButtonProps {
+interface CheckEmailButtonProps {
   onCheck: () => void;
   isLoading: boolean;
 }
 
-export const EmailCheckButton = ({ onCheck, isLoading }: EmailCheckButtonProps) => {
+export const CheckEmailButton = ({ onCheck, isLoading }: CheckEmailButtonProps) => {
   return (
     <button
       className='rounded-md bg-blue-500 px-1 font-semibold text-white transition-colors duration-300 hover:bg-blue-600 disabled:bg-blue-300'

--- a/src/features/auth/ui/EmailCheckButton.tsx
+++ b/src/features/auth/ui/EmailCheckButton.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react';
+interface EmailCheckButtonProps {
+  onCheck: () => void;
+  isLoading: boolean;
+}
 
-export const EmailCheckButton = () => {
-  const [isLoading, setIsLoading] = useState(false);
-  const [isChecked, setIsChecked] = useState(false);
-
-  const handleCheck = async () => {
-    setIsLoading(true);
-  };
-
-  return <button>Check Availability</button>;
+export const EmailCheckButton = ({ onCheck, isLoading }: EmailCheckButtonProps) => {
+  return (
+    <button
+      className='rounded-md bg-blue-500 px-1 font-semibold text-white transition-colors duration-300 hover:bg-blue-600 disabled:bg-blue-300'
+      onClick={onCheck}
+      disabled={isLoading}
+    >
+      {isLoading ? 'Checking...' : 'Check Availability'}
+    </button>
+  );
 };

--- a/src/features/auth/ui/EmailCheckButton.tsx
+++ b/src/features/auth/ui/EmailCheckButton.tsx
@@ -1,0 +1,12 @@
+import { useState } from 'react';
+
+export const EmailCheckButton = () => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [isChecked, setIsChecked] = useState(false);
+
+  const handleCheck = async () => {
+    setIsLoading(true);
+  };
+
+  return <button>Check Availability</button>;
+};

--- a/src/features/auth/ui/SignupForm.tsx
+++ b/src/features/auth/ui/SignupForm.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import { useFunnel } from '@/src/shared/hooks/useFunnel';
-import { Signup1, Signup2, Signup3 } from '@/src/widgets/signup';
+import { Signup1, Signup2, Signup3, SignupNavigateBar } from '@/src/widgets/signup';
 import { useSignup } from '../hooks/useSignup';
 
 const SIGNUP_STEPS = ['step1', 'step2', 'step3'] as const;
 
 export default function SignupForm() {
   const { Funnel, Step, useStep } = useFunnel(SIGNUP_STEPS);
-  const { setStep } = useStep();
+  const { step, setStep } = useStep();
   const { formData, error, isLoading, handleFormChange, handleSubmit } = useSignup();
 
   const handleNext = (nextStep: (typeof SIGNUP_STEPS)[number]) => {
@@ -21,6 +21,8 @@ export default function SignupForm() {
 
   return (
     <div className='flex flex-col'>
+      <SignupNavigateBar currentStep={step as 'step1' | 'step2' | 'step3'} />
+
       {error && (
         <div className='mb-4 rounded-md bg-red-50 p-4'>
           <p className='text-sm text-red-600'>{error}</p>

--- a/src/shared/utils/httpServer.ts
+++ b/src/shared/utils/httpServer.ts
@@ -16,8 +16,6 @@ async function request<T = unknown>(url: string, config: FetchConfig = {}): Prom
 
   const data = await response.json();
 
-  console.log('data@@@@@@@@@@@@@', data);
-
   if (!response.ok) {
     throw new Error(data.message || `HTTP ${response.status}`);
   }

--- a/src/widgets/signup/Signup1.tsx
+++ b/src/widgets/signup/Signup1.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useCheckEmail } from '@/src/features/auth/hooks/useCheckEmail';
-import { EmailCheckButton } from '@/src/features/auth/ui/EmailCheckButton';
+import { CheckEmailButton } from '@/src/features/auth/ui/CheckEmailButton';
 
 interface FormData {
   email: string;
@@ -53,7 +53,7 @@ export default function Signup1({ formData, onFormChange, onNext }: Signup1Props
               className='w-full rounded-md border border-gray-300 p-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-400'
               required
             />
-            <EmailCheckButton onCheck={() => checkEmail(formData.email)} isLoading={isLoading} />
+            <CheckEmailButton onCheck={() => checkEmail(formData.email)} isLoading={isLoading} />
           </div>
           {message && (
             <p className={`text-sm ${isAvailable ? 'text-green-500' : 'text-red-500'}`}>

--- a/src/widgets/signup/Signup1.tsx
+++ b/src/widgets/signup/Signup1.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import { useCheckEmail } from '@/src/features/auth/hooks/useCheckEmail';
+import { EmailCheckButton } from '@/src/features/auth/ui/EmailCheckButton';
+
 interface FormData {
   email: string;
   password: string;
@@ -17,6 +20,8 @@ interface Signup1Props {
 }
 
 export default function Signup1({ formData, onFormChange, onNext }: Signup1Props) {
+  const { message, isAvailable, checkEmail, isLoading } = useCheckEmail();
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -35,22 +40,30 @@ export default function Signup1({ formData, onFormChange, onNext }: Signup1Props
       <h3 className='mb-6 text-xl font-semibold text-gray-700'>Account Information</h3>
       <form onSubmit={handleSubmit} className='space-y-4'>
         <div>
-          <label htmlFor='email' className='mb-2 block text-sm font-medium text-gray-600'>
+          <label htmlFor='email' className='mb-2 block font-medium text-gray-600'>
             Email
           </label>
-          <input
-            id='email'
-            type='email'
-            value={formData.email}
-            onChange={(e) => onFormChange('email', e.target.value)}
-            placeholder='example@example.com'
-            className='w-full rounded-md border border-gray-300 p-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-400'
-            required
-          />
+          <div className='flex items-center gap-2'>
+            <input
+              id='email'
+              type='email'
+              value={formData.email}
+              onChange={(e) => onFormChange('email', e.target.value)}
+              placeholder='example@example.com'
+              className='w-full rounded-md border border-gray-300 p-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-400'
+              required
+            />
+            <EmailCheckButton onCheck={() => checkEmail(formData.email)} isLoading={isLoading} />
+          </div>
+          {message && (
+            <p className={`text-sm ${isAvailable ? 'text-green-500' : 'text-red-500'}`}>
+              {message}
+            </p>
+          )}
         </div>
 
         <div>
-          <label htmlFor='password' className='mb-2 block text-sm font-medium text-gray-600'>
+          <label htmlFor='password' className='mb-2 block font-medium text-gray-600'>
             Password
           </label>
           <input
@@ -65,7 +78,7 @@ export default function Signup1({ formData, onFormChange, onNext }: Signup1Props
         </div>
 
         <div>
-          <label htmlFor='passwordConfirm' className='mb-2 block text-sm font-medium text-gray-600'>
+          <label htmlFor='passwordConfirm' className='mb-2 block font-medium text-gray-600'>
             Confirm Password
           </label>
           <input

--- a/src/widgets/signup/Signup2.tsx
+++ b/src/widgets/signup/Signup2.tsx
@@ -70,7 +70,8 @@ export default function Signup2({ formData, onFormChange, onNext, onPrev }: Sign
             type='date'
             value={formData.birthDate}
             onChange={(e) => onFormChange('birthDate', e.target.value)}
-            className='w-full rounded-md border border-gray-300 p-3 outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-400'
+            className='w-full rounded-md border border-gray-300 p-3 text-black outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-400 [&::-webkit-calendar-picker-indicator]:rounded [&::-webkit-calendar-picker-indicator]:bg-gray-300 [&::-webkit-calendar-picker-indicator]:p-1 [&::-webkit-calendar-picker-indicator]:hover:bg-gray-400'
+            lang='en'
             required
           />
         </div>

--- a/src/widgets/signup/SignupNavigateBar.tsx
+++ b/src/widgets/signup/SignupNavigateBar.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { FaCheck } from 'react-icons/fa';
+
+interface SignupNavigateBarProps {
+  currentStep: 'step1' | 'step2' | 'step3';
+}
+
+export const SignupNavigateBar = ({ currentStep }: SignupNavigateBarProps) => {
+  const steps = [
+    { id: 'step1', label: 'Account Info' },
+    { id: 'step2', label: 'Personal Info' },
+    { id: 'step3', label: 'Confirm' },
+  ];
+
+  const getCurrentStepIndex = () => {
+    return steps.findIndex((step) => step.id === currentStep);
+  };
+
+  const currentStepIndex = getCurrentStepIndex();
+
+  return (
+    <div className='mb-4 flex w-full items-center justify-center'>
+      <div className='flex items-center'>
+        {steps.map((step, index) => {
+          const isActive = step.id === currentStep;
+          const isCompleted = index < currentStepIndex;
+
+          return (
+            <div key={step.id} className='flex items-center'>
+              <div className='flex w-22 flex-col items-center md:w-24'>
+                <div
+                  className={`flex h-10 w-10 items-center justify-center rounded-full border-2 text-sm font-semibold transition-all duration-200 ${
+                    isActive
+                      ? 'border-blue-500 bg-blue-500 text-white'
+                      : isCompleted
+                        ? 'border-green-500 bg-green-500 text-white'
+                        : 'border-gray-300 bg-white text-gray-400'
+                  }`}
+                >
+                  {isCompleted ? <FaCheck className='h-4 w-4' /> : index + 1}
+                </div>
+                <div className='mt-2 text-center'>
+                  <div
+                    className={`md:text-md text-sm ${
+                      isActive ? 'text-blue-600' : isCompleted ? 'text-green-600' : 'text-gray-400'
+                    }`}
+                  >
+                    {step.label}
+                  </div>
+                </div>
+              </div>
+
+              {index < steps.length - 1 && (
+                <div className='mx-1 h-0.5 w-5 bg-gray-300 md:mx-4'>
+                  <div
+                    className={`h-full transition-all duration-200 ${
+                      isCompleted ? 'bg-green-500' : 'bg-gray-300'
+                    }`}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/src/widgets/signup/index.ts
+++ b/src/widgets/signup/index.ts
@@ -1,3 +1,4 @@
 export { default as Signup1 } from './Signup1';
 export { default as Signup2 } from './Signup2';
 export { default as Signup3 } from './Signup3';
+export { SignupNavigateBar } from './SignupNavigateBar';


### PR DESCRIPTION
## 🚩 연관 이슈

closed #41 

## 📝 작업 내용
- 이메일 중복 확인 Route API 구현
- 이메일 중복 확인 Client API 구현
- `useCheckEmail` 훅 구현
- `CheckEmailButton` UI 컴포넌트 구현 
- step에 따른 `signupNavigateBar` 컴포넌트 구현 

## 스크린샷

<img width="860" height="1354" alt="image" src="https://github.com/user-attachments/assets/be42595f-1f50-4160-aad8-f7abaadea00f" />
