### PR TITLE
[FEAT] RefreshToken Route API 구현

### DIFF
--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,4 +1,3 @@
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
@@ -19,47 +18,42 @@ export async function GET(req: NextRequest) {
       return NextResponse.redirect(new URL('/login?error=oauth_failed', req.url));
     }
 
+    const res = NextResponse.json({
+      email,
+      name,
+      profileImageUrl,
+    });
+
     if (success === 'true' && accessToken && refreshToken) {
-      const cookieStore = await cookies();
-      cookieStore.set('accessToken', accessToken, {
+      res.cookies.set('accessToken', accessToken, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: true,
         sameSite: 'strict',
         path: '/',
         maxAge: 60 * 60,
       });
 
-      cookieStore.set('refreshToken', refreshToken, {
+      res.cookies.set('refreshToken', refreshToken, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: true,
         sameSite: 'strict',
         path: '/',
         maxAge: 60 * 60 * 24 * 7,
       });
 
-      return NextResponse.json({
-        email,
-        name,
-        profileImageUrl,
-      });
+      return res;
     }
 
     if (tempToken) {
-      const cookieStore = await cookies();
-
-      cookieStore.set('tempToken', tempToken, {
+      res.cookies.set('tempToken', tempToken, {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
+        secure: true,
         sameSite: 'strict',
         path: '/',
         maxAge: 60 * 30,
       });
 
-      return NextResponse.json({
-        email,
-        name,
-        profileImageUrl,
-      });
+      return res;
     }
 
     console.error('No Temp Token');

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -1,6 +1,5 @@
 import { Profile } from '@/src/features/auth/types/auth';
 import { httpServer } from '@/src/shared/utils/httpServer';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 interface LoginResponse {
@@ -22,23 +21,24 @@ export async function POST(req: NextRequest) {
     const response: LoginResponse = await httpServer.post('/auth/login', { email, password });
     const { accessToken, refreshToken } = response.data;
 
-    const cookieStore = await cookies();
-    cookieStore.set('accessToken', accessToken, {
+    const res = NextResponse.json({ message: '로그인 성공' });
+
+    res.cookies.set('accessToken', accessToken, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: true,
       sameSite: 'strict',
       path: '/',
-      maxAge: 60 * 60, // 1시간
+      maxAge: 60 * 60,
     });
-    cookieStore.set('refreshToken', refreshToken, {
+    res.cookies.set('refreshToken', refreshToken, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: true,
       sameSite: 'strict',
       path: '/',
-      maxAge: 60 * 60 * 24 * 7, // 7일
+      maxAge: 60 * 60 * 24 * 7,
     });
 
-    return NextResponse.json({ message: '로그인 성공' }, { status: 200 });
+    return res;
   } catch (error) {
     return NextResponse.json({ message: error }, { status: 500 });
   }

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,9 +1,9 @@
-import { deleteTokens, getAccessToken } from '@/src/shared/utils/cookieService';
+import { getValidAccessToken } from '@/src/shared/utils/cookieService';
 import { httpServer } from '@/src/shared/utils/httpServer';
 import { NextResponse } from 'next/server';
 
 export async function POST() {
-  const accessToken = await getAccessToken();
+  const accessToken = await getValidAccessToken();
 
   if (!accessToken) {
     return NextResponse.json({ message: '로그아웃 실패' }, { status: 401 });
@@ -16,8 +16,18 @@ export async function POST() {
       },
     });
 
-    await deleteTokens();
-    return NextResponse.json({ message: '로그아웃 성공' }, { status: 200 });
+    const res = NextResponse.json({ message: '로그아웃 성공' }, { status: 200 });
+
+    res.cookies.set('accessToken', '', {
+      path: '/',
+      maxAge: 0,
+    });
+    res.cookies.set('refreshToken', '', {
+      path: '/',
+      maxAge: 0,
+    });
+
+    return res;
   } catch (error) {
     return NextResponse.json({ message: error }, { status: 500 });
   }

--- a/app/api/auth/profile/route.ts
+++ b/app/api/auth/profile/route.ts
@@ -1,10 +1,10 @@
 import { Profile } from '@/src/features/auth/types/auth';
-import { getAccessToken } from '@/src/shared/utils/cookieService';
+import { getValidAccessToken } from '@/src/shared/utils/cookieService';
 import { httpServer } from '@/src/shared/utils/httpServer';
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const accessToken = await getAccessToken();
+  const accessToken = await getValidAccessToken();
   if (!accessToken) {
     return NextResponse.json({ message: '프로필 조회 실패' }, { status: 401 });
   }

--- a/app/api/auth/signupGoogle/route.ts
+++ b/app/api/auth/signupGoogle/route.ts
@@ -1,7 +1,6 @@
 import { Profile } from '@/src/features/auth/types/auth';
 import { getTempToken } from '@/src/shared/utils/cookieService';
 import { httpServer } from '@/src/shared/utils/httpServer';
-import { cookies } from 'next/headers';
 import { NextRequest, NextResponse } from 'next/server';
 
 interface SignupGoogleResponse {
@@ -29,17 +28,18 @@ export async function POST(req: NextRequest) {
 
     const { accessToken, refreshToken, user } = response.data;
 
-    const cookieStore = await cookies();
-    cookieStore.set('accessToken', accessToken, {
+    const res = NextResponse.json({ message: '회원가입 성공' }, { status: 201 });
+
+    res.cookies.set('accessToken', accessToken, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: true,
       sameSite: 'strict',
       path: '/',
       maxAge: 60 * 60, // 1시간
     });
-    cookieStore.set('refreshToken', refreshToken, {
+    res.cookies.set('refreshToken', refreshToken, {
       httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
+      secure: true,
       sameSite: 'strict',
       path: '/',
       maxAge: 60 * 60 * 24 * 7, // 7일

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,14 @@
 import type { Metadata } from 'next';
 
-import './globals.css';
-import localFont from 'next/font/local';
-import ConditionalBottomNavigateBar from '@/src/widgets/bottomNavigateBar/ui/ConditionalBottomNavigateBar';
 import StructuredData, {
-  websiteStructuredData,
-  webApplicationStructuredData,
-  organizationStructuredData,
   medicalWebsiteStructuredData,
+  organizationStructuredData,
+  webApplicationStructuredData,
+  websiteStructuredData,
 } from '@/src/shared/ui/StructuredData';
+import ConditionalBottomNavigateBar from '@/src/widgets/bottomNavigateBar/ui/ConditionalBottomNavigateBar';
+import localFont from 'next/font/local';
+import './globals.css';
 
 const iansui = localFont({
   src: '../public/fonts/iansui.woff2',
@@ -18,7 +18,7 @@ const iansui = localFont({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://vitaltrip.vercel.app'),
+  metadataBase: new URL('https://aivitaltrip.com'),
   title: {
     default: 'VitalTrip - Your Emergency Travel Companion',
     template: '%s | VitalTrip',
@@ -45,7 +45,7 @@ export const metadata: Metadata = {
     'medical tourism',
     'healthcare travel',
   ],
-  authors: [{ name: 'VitalTrip Team', url: 'https://vitaltrip.vercel.app' }],
+  authors: [{ name: 'VitalTrip Team', url: 'https://aivitaltrip.com' }],
   creator: 'VitalTrip',
   publisher: 'VitalTrip',
   applicationName: 'VitalTrip',

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = 'https://vitaltrip.vercel.app';
+  const baseUrl = 'https://aivitaltrip.com';
 
   return {
     rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://vitaltrip.vercel.app';
+  const baseUrl = 'https://aivitaltrip.com';
   const currentDate = new Date();
 
   return [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "travel companion"
   ],
   "author": "VitalTrip Team",
-  "homepage": "https://vitaltrip.vercel.app",
+  "homepage": "https://aivitaltrip.com",
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build",

--- a/src/features/auth/hooks/useCheckEmail.ts
+++ b/src/features/auth/hooks/useCheckEmail.ts
@@ -12,14 +12,14 @@ export const useCheckEmail = () => {
       const { available } = await checkEmailApi(email);
       if (available) {
         setIsAvailable(true);
-        setMessage('사용 가능한 이메일입니다.');
+        setMessage('This email is available.');
       } else if (!available) {
         setIsAvailable(false);
-        setMessage('이미 사용 중인 이메일입니다.');
+        setMessage('This email is already in use.');
       }
     } catch {
       setIsAvailable(false);
-      setMessage('이메일 중복 확인에 실패했습니다.');
+      setMessage('Failed to check email availability.');
     } finally {
       setIsLoading(false);
     }

--- a/src/shared/utils/cookieService.ts
+++ b/src/shared/utils/cookieService.ts
@@ -1,13 +1,41 @@
 import { cookies } from 'next/headers';
+import { httpServer } from './httpServer';
 
-export const getAccessToken = async () => {
+interface ValidAccessTokenResponse {
+  message: string;
+  data: {
+    accessToken: string;
+  };
+}
+
+export async function getValidAccessToken(): Promise<string | null> {
   const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken');
-  if (!accessToken) {
-    return null;
+  let accessToken = cookieStore.get('accessToken')?.value;
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+
+  if (!accessToken && refreshToken) {
+    try {
+      const response: ValidAccessTokenResponse = await httpServer.post('/auth/refresh', {
+        refreshToken,
+      });
+
+      accessToken = response.data.accessToken;
+      cookieStore.set('accessToken', accessToken, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        path: '/',
+        maxAge: 60 * 60,
+      });
+
+      return accessToken;
+    } catch (error) {
+      return null;
+    }
   }
-  return accessToken?.value;
-};
+
+  return accessToken ?? null;
+}
 
 export const getTempToken = async () => {
   const cookieStore = await cookies();

--- a/src/shared/utils/cookieService.ts
+++ b/src/shared/utils/cookieService.ts
@@ -30,6 +30,7 @@ export async function getValidAccessToken(): Promise<string | null> {
 
       return accessToken;
     } catch (error) {
+      console.error('accessToken 재발급 실패', error);
       return null;
     }
   }


### PR DESCRIPTION
## 🚩 연관 이슈

closed #50 

## 📝 작업 내용
- RefreshToken Route API 로직이 담긴 공통 util 함수 구현
- AccessToken 만료 시 RefreshToken을 통하여 API 호출
- AccessToken을 header에 담는 로직이 담긴 route.ts 파일에 모두 적용하여 리팩토링

