### PR TITLE
[FEAT] 사용자 위치에 따른 국가 응급 번호 및 국가 정보 호출 로직 구현

### DIFF
--- a/client/app/api/identify-country/route.ts
+++ b/client/app/api/identify-country/route.ts
@@ -1,0 +1,23 @@
+import {
+  IdentifyCountryRequest,
+  IdentifyCountryResponse,
+} from '@/src/features/medical/types/location';
+import { httpServer } from '@/src/shared/utils/httpServer';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(
+  request: NextRequest,
+): Promise<NextResponse<IdentifyCountryResponse | { error: string }>> {
+  try {
+    const body: IdentifyCountryRequest = await request.json();
+
+    const result: IdentifyCountryResponse = await httpServer.post(
+      '/location/identify-country',
+      body,
+    );
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error('국가 식별 API 오류:', error);
+    return NextResponse.json({ error: '국가 식별 중 오류가 발생했습니다.' }, { status: 500 });
+  }
+}

--- a/client/src/features/medical/api/useIdentifyCountryMutation.ts
+++ b/client/src/features/medical/api/useIdentifyCountryMutation.ts
@@ -1,0 +1,18 @@
+import { httpClient } from '@/src/shared/utils/httpClient';
+import { useMutation } from '@tanstack/react-query';
+import { IdentifyCountryRequest, IdentifyCountryResponse } from '../types/location';
+
+export const useIdentifyCountryMutation = () => {
+  return useMutation({
+    mutationFn: identifyCountry,
+    onError: (error) => {
+      console.error('국가 식별 오류:', error);
+    },
+  });
+};
+
+const identifyCountry = async (
+  request: IdentifyCountryRequest,
+): Promise<IdentifyCountryResponse> => {
+  return await httpClient.post<IdentifyCountryResponse>('/api/identify-country', request);
+};

--- a/client/src/features/medical/types/location.ts
+++ b/client/src/features/medical/types/location.ts
@@ -1,0 +1,24 @@
+export interface IdentifyCountryRequest {
+  latitude: number;
+  longitude: number;
+}
+
+export interface EmergencyContact {
+  fire: string | null;
+  police: string | null;
+  medical: string | null;
+  general: string | null;
+}
+
+export interface IdentifyCountryData {
+  countryCode: string;
+  countryName: string;
+  latitude: number;
+  longitude: number;
+  emergencyContact: EmergencyContact | null;
+}
+
+export interface IdentifyCountryResponse {
+  message: string;
+  data: IdentifyCountryData;
+}


### PR DESCRIPTION
## 🚩 연관 이슈

closed #86 

## 📝 작업 내용

사용자의 현재 위치(위도, 경도)를 기반으로 해당 국가를 자동 식별하고, 그 국가의 응급 연락처(소방서, 경찰서, 응급의료)를 실시간으로 제공하는 기능을 개발했습니다.

## API 엔드포인트
POST `/api/identify-country`

- 위경도 좌표를 받아 국가 식별 및 응급 연락처 반환
- 백엔드 API와 연동하여 70+ 개국 지원

## 프론트엔드 통합
- 기존 EmergencyCall 컴포넌트에 실시간 위치 기반 기능 추가
- useCurrentLocation 훅을 활용한 자동 위치 감지
- React Query를 통한 효율적인 API 상태 관리

## 타입 안전성
- TypeScript 인터페이스로 API 요청/응답 구조 정의
- location.ts에 타입 집중화

## 🏞️ 스크린샷 (선택)


<img width="2880" height="1456" alt="image" src="https://github.com/user-attachments/assets/8d1397ed-0e28-4e3f-8148-a92bb12bb4c2" />
